### PR TITLE
Remove usage of obsolete PHP configuration directives

### DIFF
--- a/source/prerequisites.rst
+++ b/source/prerequisites.rst
@@ -69,8 +69,6 @@ PHP configuration file (``php.ini``) must be adapted to reflect following variab
     memory_limit = 64M ;        // max memory limit
     file_uploads = on ;
     max_execution_time = 600 ;  // not mandatory but recommended
-    register_globals = off ;    // not mandatory but recommended
-    magic_quotes_sybase = off ;
     session.auto_start = off ;
     session.use_trans_sid = 0 ; // not mandatory but recommended
 


### PR DESCRIPTION
These configuration directives were removed in PHP 5.4.0.