### PR TITLE
Updated glpi:system:check_requirments command

### DIFF
--- a/source/command-line.rst
+++ b/source/command-line.rst
@@ -37,7 +37,7 @@ Additional install and update tools
 Check requirements
 ^^^^^^^^^^^^^^^^^^
 
-Before installing or upgrading, requirements are automatically checked; but you can run them separately and see state for all of them using the ``glpi:system:check_requirements`` command.
+Before installing or upgrading, requirements are automatically checked; but you can run them separately and see state for all of them using the ``php bin/console glpi:system:check_requirements`` command.
 
 Enable/Disable maintenance
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Added php bin/console before glpi:system:check_requirements command.  On Ubuntu 20.04 if you run glpi:system:check_requirements you get an error about the command not found.  Putting php bin/console before resolves this issue.