### PR TITLE
Fix README.md (added sphinx_glpi_theme package)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If your distribution does not provide this version, you could use a `virtualenv`
 ```
 $ virtualenv /path/to/virtualenv/files
 $ /path/to/virtualenv/bin/activate
-$ pip install sphinx
+$ pip install sphinx sphinx_glpi_theme
 ```
 
 Once all has been successfully installed, just run the following to build the documentation:


### PR DESCRIPTION
There is an error without this package:

```
(doc-install) vl@lin:~/translate/doc-install$ make html
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v4.0.2

Configuration error:
There is a programmable error in your configuration file:a

Traceback (most recent call last):
  File "/home/vl/translate/doc-install/lib/python3.8/site-packages/sphinx/config.py", line 323, in eval_config_file
    exec(code, namespace)
  File "/home/vl/translate/doc-install/source/conf.py", line 16, in <module>
    import sphinx_glpi_theme
ModuleNotFoundError: No module named 'sphinx_glpi_theme'

make: *** [Makefile:53: html] Error 2
```