### PR TITLE
Add supported PHP version matrix

### DIFF
--- a/source/prerequisites.rst
+++ b/source/prerequisites.rst
@@ -19,11 +19,17 @@ GLPI requires a web server that supports PHP, like:
 PHP
 ---
 
-As of 9.5 release, GLPI requires `PHP <http://php.net>`_ 7.2 or more recent.
+Compatibility Matrix
+
+| GLPI Version | Minimum PHP | Maximum PHP |
+| ------------ | ----------- | ----------- |
+| 9.4.X        | 5.6         | 7.4         |
+| 9.5.X        | 7.2         | 8.0         |
+| 10.0.X       | 7.4         | 8.1         |
 
 .. note::
 
-   We recommend to use the most recent stable PHP release for better performances.
+   We recommend to use the newest supported PHP release for better performance.
 
 Mandatory extensions
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Instead of just saying >= a PHP version, use a matrix to show minimum and maximum supported (tested) versions.
There was some confusion in the forums about GLPI 9.5 and PHP 8.1 compatibility because the docs said 9.5 worked with "7.2 or more recent".

I only went back to 9.4.X with compatibility.