### PR TITLE
Specify the the key file needs backed up

### DIFF
--- a/source/update.rst
+++ b/source/update.rst
@@ -7,7 +7,7 @@ Update
 
    * **backup your database**;
    * backup your files directory;
-   * backup your configuration (especially your GLPI key file `config/glpicrypt.key` if present).
+   * backup your configuration (especially your GLPI key file `config/glpi.key` or `config/glpicrypt.key` if present).
 
 First, download latest GLPI version and extract files. GLPI update process is then automated. To start it, just go to your GLPI instance URI, or (recommended) use the :doc:`command line tools <command-line>`.
 

--- a/source/update.rst
+++ b/source/update.rst
@@ -7,7 +7,7 @@ Update
 
    * **backup your database**;
    * backup your files directory;
-   * backup your configuration.
+   * backup your configuration (especially your GLPI key file `config/glpicrypt.key` if present).
 
 First, download latest GLPI version and extract files. GLPI update process is then automated. To start it, just go to your GLPI instance URI, or (recommended) use the :doc:`command line tools <command-line>`.
 


### PR DESCRIPTION
The docs already list the configuration (config folder?) as something needed to be backed up when doing an upgrade, but unlike the DB config, the key file is something that they cannot easily recreate when they have already encrypted data in the DB. It may be best to specifically mention this file to help ensure it is being backed up/migrated.