### PR TITLE
Update prerequisites documentation

### DIFF
--- a/source/prerequisites.rst
+++ b/source/prerequisites.rst
@@ -125,15 +125,12 @@ PHP
    * - GLPI Version
      - Minimum PHP
      - Maximum PHP
-   * - 9.4.X
-     - 5.6
-     - 7.4
    * - 9.5.X
      - 7.2
      - 8.0
    * - 10.0.X
      - 7.4
-     - 8.1
+     - 8.2
 
 .. note::
 
@@ -144,17 +141,13 @@ Mandatory extensions
 
 Following PHP extensions are required for the app to work properly:
 
-* ``curl``: for CAS authentication, GLPI version check, Telemetry, ...;
-* ``fileinfo``: to get extra informations on files;
-* ``gd``: to generate images;
-* ``json``: to get support for JSON data format;
-* ``mbstring``:  to manage multi bytes characters;
-* ``mysqli``: to connect and query the database;
-* ``session``: to get user sessions support;
-* ``zlib``: to get backup and restore database functions;
-* ``simplexml``;
-* ``xml``;
-* ``intl``.
+* ``dom``, ``fileinfo``, ``filter``, ``libxml``, ``json``, ``simplexml``, ``xmlreader``, ``xmlwriter``: these PHP extensions are enable by default and are used for various operations;
+* ``curl``: used for remote access to resources (inventory agent requests, marketplace, RSS feeds, ...);
+* ``gd``: used for images handling;
+* ``intl``: used for internationalization;
+* ``mysqli``: used for database connection;
+* ``session``: used for sessions support;
+* ``zlib``: used for handling of compressed communication with inventory agents, installation of gzip packages from marketplace and PDF generation.
 
 Optional extensions
 ^^^^^^^^^^^^^^^^^^^
@@ -165,25 +158,11 @@ Optional extensions
 
 Following PHP extensions are required for some extra features of GLPI:
 
-* ``cli``: to use PHP from command line (scripts, automatic actions, and so on);
-* ``domxml``: used for CAS authentication;
-* ``ldap``:  use LDAP directory for authentication;
-* ``openssl``: secured communications;
-* ``xmlrpc``: used for XMLRPC API.
-* ``APCu``: may be used for cache; among others (see `caching configuration (in french only) <http://glpi-user-documentation.readthedocs.io/fr/latest/advanced/cache.html>`_.
-
-Configuration
-^^^^^^^^^^^^^
-
-PHP configuration file (``php.ini``) must be adapted to reflect following variables:
-
-.. code-block:: ini
-
-    memory_limit = 64M ;        // max memory limit
-    file_uploads = on ;
-    max_execution_time = 600 ;  // not mandatory but recommended
-    session.auto_start = off ;
-    session.use_trans_sid = 0 ; // not mandatory but recommended
+* ``bz2``, ``Phar``, ``zip``: enable support of most common packages formats in marketplace;
+* ``exif``: enhance security on images validation;
+* ``ldap``:  enable usage of authentication through remote LDAP server;
+* ``openssl``: enable email sending using SSL/TLS;
+* ``Zend OPcache``: enhance PHP engine performances.
 
 Database
 --------


### PR DESCRIPTION
1. Remove GLPI 9.4 version for PHP versions matrix.
2. Set PHP 8.2 as max supported version for GLPI 10.0.X.
3. Update mandatory/optional extensions list.
4. Remove PHP configuration section. Default PHP configuration matches GLPI prerequisites, and we should not encourage people to change it.