### PR TITLE
Clarify usage of Alias directive

### DIFF
--- a/source/prerequisites.rst
+++ b/source/prerequisites.rst
@@ -34,7 +34,7 @@ Here is a virtual host configuration example for ``Apache 2`` web server.
         DocumentRoot /var/www/glpi/public
 
         # If you want to place GLPI in a subfolder of your site (e.g. your virtual host is serving multiple applications),
-        # you can use an Alias directive:
+        # you can use an Alias directive. If you do this, the DocumentRoot directive MUST NOT target the GLPI directory itself.
         # Alias "/glpi" "/var/www/glpi/public"
 
         <Directory /var/www/glpi/public>


### PR DESCRIPTION
I already had to explain this to multiple customers that were using the same path in both DocumentRoot and Alias directive.