### PR TITLE
Update prerequisites.rst

### DIFF
--- a/source/prerequisites.rst
+++ b/source/prerequisites.rst
@@ -152,9 +152,6 @@ PHP
    * - GLPI Version
      - Minimum PHP
      - Maximum PHP
-   * - 9.5.X
-     - 7.2
-     - 8.0
    * - 10.0.X
      - 7.4
      - 8.2


### PR DESCRIPTION
I've removed the version 9.5 minimum PHP and Mysql Compatibility table.