### PR TITLE
Indicates that granting access to timezones is no longuer necessary

### DIFF
--- a/source/timezones.rst
+++ b/source/timezones.rst
@@ -36,6 +36,10 @@ See `MariaDB documentation about timezones <https://mariadb.com/kb/en/library/ti
 Grant access
 ------------
 
+.. note::
+
+    Before GLPI 10.0.20, granting access to the ``mysql.time_zone_name`` table was required to support timezones usage. This is no longuer required.
+
 .. warning::
 
    Be carefull not to give your GLPI database user too large access. System tables should **never** grant access to app users.

--- a/source/timezones.rst
+++ b/source/timezones.rst
@@ -36,9 +36,8 @@ See `MariaDB documentation about timezones <https://mariadb.com/kb/en/library/ti
 Grant access
 ------------
 
-.. note::
-
-    Before GLPI 10.0.20, granting access to the ``mysql.time_zone_name`` table was required to support timezones usage. This is no longuer required.
+.. versionremoved:: 10.0.20 
+    Granting access to the ``mysql.time_zone_name`` is no longer required to support timezones usage.
 
 .. warning::
 


### PR DESCRIPTION
Maybe this `Grant access` section can be completely removed, but we will then have to wait for the GLPI 10.0.20 release to be able to merge this change.