### PR TITLE
Upgrade mariadb minimum version for 11.x

### DIFF
--- a/source/prerequisites.rst
+++ b/source/prerequisites.rst
@@ -241,7 +241,7 @@ In order to work, GLPI requires a database server.
      - 8.0
    * - 11.0.X
      - MariaDB
-     - 10.5
+     - 10.6
 
 .. note::
 


### PR DESCRIPTION
From an issue in the [main repo](https://github.com/glpi-project/glpi/issues/21393)

MariaDB 10.6 is already shown as minimal version in main readme, 10.5 support dropped in [this PR](https://github.com/glpi-project/glpi/pull/20156)

This PR is to align installation documentation with other sources